### PR TITLE
feat: separate like and comment feedback process

### DIFF
--- a/feedback.py
+++ b/feedback.py
@@ -1,64 +1,135 @@
 import os
-from uuid import uuid4
+import re
 from gql import gql, Client
 from gql.transport.aiohttp import AIOHTTPTransport
 
 
 gql_endpoint = os.environ['GQL_ENDPOINT']
+like_form_id = os.environ['LIKE_FORM_ID']
+comment_form_id = os.environ['COMMENT_FORM_ID']
+like_field_id = os.environ['LIKE_FIELD_ID']
+comment_field_id = os.environ['COMMENT_FIELD_ID']
+
+
+
 gql_transport = AIOHTTPTransport(url=gql_endpoint)
 gql_client = Client(transport=gql_transport, fetch_schema_from_transport=True)
-def create_feedback(data):
-  create_result = []
-  name = str(uuid4())
-  form = data['form']
-  ip = data['ip']
-  responseTime = data['responseTime']
-  for result in data['result']:
-    field = result['field']
-    result = result['userFeedback']
-    mutation_data = '''
-      data: {
-        name: "%s",
-        ip: "%s",
-        result: "%s",
-        responseTime: "%s",
-        form: {
-          connect: {
-            id: "%s"
-          }
-        },
-        field: {
-          connect: {
-            id: "%s"
+def create_formResult(gql_client, name, ip, result, responseTime, form, field):
+  mutation_data = '''
+        data: {
+          name: "%s",
+          ip: "%s",
+          result: "%s",
+          responseTime: "%s",
+          form: {
+            connect: {
+              id: "%s"
+            }
+          },
+          field: {
+            connect: {
+              id: "%s"
+            }
           }
         }
-      }
-    ''' %(name, ip, result, responseTime, form, field)
-    mutation = '''
+      ''' %(name, ip, result, responseTime, form, field)
+  createFormResult = '''
     mutation{
       createFormResult(%s){
         id
       }
     }
     ''' % mutation_data
-    print(mutation)
-    result = gql_client.execute(gql(mutation))
-    print(result)
-    if not isinstance(result, dict) and 'createFormResult' not in result:
-      print(result)
+  print(createFormResult)
+  mutation_result = gql_client.execute(gql(createFormResult))
+  if not isinstance(mutation_result, dict) and 'createFormResult' not in mutation_result:
+    print(mutation_result)
+    return False
+  if isinstance(mutation_result['createFormResult'], dict) and 'id' in mutation_result['createFormResult']:
+    return True
+  else: 
+    print(mutation_result)
+    return False
+def delete_name_exist_result(gql_client, name):
+  query = '''query{
+    formResults(where:{name:{in:"%s"} ,field:{id:{in:%s}}} orderBy:{name:desc}){
+      id
+    }
+  }
+''' %(name, like_field_id)
+  print(query)
+  query_result = gql_client.execute(gql(query))
+  if isinstance(query_result, dict) and 'formResults' in query_result:
+    if query_result['formResults']:
+      #the user's feed-like result in formResults
+      id = query_result['formResults'][0]['id']
+      deleteFormResult = '''
+      mutation{
+          deleteFormResult(where:{id:%s}){
+            id
+          }
+        }'''% id
+      print(deleteFormResult)
+      mutation_result = gql_client.execute(gql(deleteFormResult))
+      if not isinstance(mutation_result, dict) and 'deleteFormResult' not in mutation_result:
+        print(mutation_result)
+        print("deleteFormResult fail")
+        return False
+      if isinstance(mutation_result['deleteFormResult'], dict) and 'id' in mutation_result['deleteFormResult']:
+        return True
+      else: 
+        print(mutation_result)
+        print("deleteFormResult fail")
+        return False
+
+
+    else:
+      #user feed-like result not in formResults
+      return True
+      
+
+def feedback_handler(data):
+  name = data['name']
+  form = data['form']
+  field = data['field']
+  result = data['userFeedback'].lower()
+  ip = data['ip']
+  responseTime = data['responseTime']
+
+  ip_regex = re.compile(r'[0-9]+[.][0-9]+[.][0-9]+[.][0-9]+')
+  if not re.fullmatch(ip_regex, ip) :
+    print("ip format not match.")
+    return False
+  responseTime_regex = re.compile(r'20[0-9][0-9]-(0?[1-9]|1[0-2])-(0?[1-9]|[12]\d|30|31)T([01][0-9]|2[0-3]):([0-5][0-9]|60):([0-5][0-9]|60).([0-9][0-9][0-9])Z')
+  if not re.fullmatch(responseTime_regex, responseTime) :
+    print("responseTime format not match.")
+    return False
+
+  if (form == like_form_id and field == like_field_id) or (form == comment_form_id and field == comment_field_id):
+    if field == comment_field_id:
+      return create_formResult(gql_client, name, ip, result, responseTime, form, field)
+    elif field == like_field_id:
+      if delete_name_exist_result(gql_client, name) is False:
+        return False
+      if result == 'true' or result == 'false':
+        return create_formResult(gql_client, name, ip, result, responseTime, form, field) 
+      else: 
+        return True
+    else:
+      print("field not match.")
       return False
-    if isinstance(result['createFormResult'], dict) and 'id' in result['createFormResult']:
-      create_result.append(result['createFormResult']['id'])
-    else: 
-      print(result)
-      return False
-  return True
+  else:
+    print("form and field not match.")
+    return False
+
+
 if __name__ == '__main__':
-  data = {"form": "2",
-  "ip": "0.0.0.0",
+  data_comment = {
+  "name": "uuid",
+  "form": "3",
+  "ip": "2.1.1.22",
   "responseTime": '2022-05-19T05:00:00.000Z',
-  "result": [
-      {"field": "6", "userFeedback": "不符合"},
-      {"field": "7", "userFeedback": "巴拉巴拉使用者的實際經驗～～"},
-]}
-  create_feedback(data)
+  "field": "7", 
+  "userFeedback": "使用者的實際經驗感想",
+  }
+  print(feedback_handler(data_comment))

--- a/server.py
+++ b/server.py
@@ -1,7 +1,7 @@
 import base64
 import ast
 from flask import Flask, request, Response
-from feedback import create_feedback
+from feedback import feedback_handler
 
 app = Flask(__name__)
 
@@ -18,7 +18,7 @@ def insert_feedback():
     content = base64.b64decode(req["message"]["data"]).decode("utf-8")
     content = ast.literal_eval(content)
     print(content)
-    if create_feedback(content):
+    if feedback_handler(content):
         return "success"
     else:
         return Response("{'error': 'insert data error'}", status=500, mimetype='application/json')


### PR DESCRIPTION
需求：為了將like和comment form分離和使用者可重複更改like，同一使用者的name由前端帶入，以判斷為同一使用者，而同一使用者的多次comment 都會新增

1. 進來的資料新增name欄位
2. 將like和comment form分離，具有各自的form和field 
3. 依據field id 判斷有不同處理
4. 每則comment 都會新增
5. like的值為true false null
6. like先判斷同樣name是否已經存在在filed result裡，若不存在會直接新增一筆
7. 若存在會先刪掉，且值為true 或false時，會新增一筆field result


